### PR TITLE
feat(builders): :sparkles: support comma separated projects as the scope

### DIFF
--- a/libs/builders/src/semantic-release/README.md
+++ b/libs/builders/src/semantic-release/README.md
@@ -68,10 +68,11 @@ If using just the Angular CLI, make sure to perform releases according to the or
 
 With this mode each releasable library will have its own version according to [semver](https://semver.org/). This is the preferred approach.
 
-[Conventional commits](https://www.conventionalcommits.org/) follow the pattern `<type>[(optional scope)]: <description>`. When the builder is configured in `independent` mode, only the following commits will considered that apply for the individual project:
+[Conventional commits](https://www.conventionalcommits.org/) follow the pattern `<type>[(optional scope)]: <description>`. When the builder is configured in `independent` mode, only the following commits will considered that apply for the individual project based on the scope:
 
-- Those without scope or scope equal to `*`
+- No scope, `*` or `deps`
 - Those where the scope is equal to the project name
+- If the scope is a comma separated list, the project name should be one of the items
 
 Example of `angular.json`/`workspace.json`:
 
@@ -79,7 +80,12 @@ Example of `angular.json`/`workspace.json`:
 {
   "projects": {
     "library": {
-      // Only commits like "feat: new feature", "feat(*): new feature" or "feat(library): new feature" will be considered
+      // Only these commits will be considered:
+      //   - feat: new feature
+      //   - feat(*): new feature
+      //   - feat(deps): upgrade dependency
+      //   - feat(library): new feature
+      //   - feat(library,some-other-library): new feature
       "targets": {
         "build": {
           /* */

--- a/libs/builders/src/semantic-release/lib/get-analyze-commits-options.ts
+++ b/libs/builders/src/semantic-release/lib/get-analyze-commits-options.ts
@@ -1,19 +1,19 @@
-interface ParserOptions {
+export interface ParserOptions {
   headerPattern: RegExp;
 }
 
-interface ReleaseRule {
+export interface ReleaseRule {
   type: string;
   release: string;
   scope?: string;
 }
 
-interface AnalyzeCommitsOptions {
+export interface AnalyzeCommitsOptions {
   releaseRules: ReleaseRule[];
   parserOpts: ParserOptions;
 }
 
-const baseReleaseRules: ReleaseRule[] = [
+const releaseRules: ReleaseRule[] = [
   { type: 'feat', release: 'minor' },
   { type: 'fix', release: 'patch' },
   { type: 'perf', release: 'patch' },
@@ -21,23 +21,17 @@ const baseReleaseRules: ReleaseRule[] = [
 ];
 
 export function getAnalyzeCommitsOptions(projects: string[], mode: 'independent' | 'sync' | 'group'): AnalyzeCommitsOptions {
-  let parserOpts: ParserOptions;
-  let releaseRules: ReleaseRule[];
+  let headerPattern: RegExp;
 
   if (mode === 'independent' || mode === 'group') {
-    parserOpts = {
-      headerPattern: new RegExp(`^(\\w*)(?:\\((${projects.map((project) => escapeRegExp(project)).join('|')}|\\*|deps)\\))?: (.*)$`),
-    };
-    releaseRules = [];
-    projects.forEach((project) => {
-      baseReleaseRules.forEach((rule) => releaseRules.push({ ...rule, scope: project }));
-    });
+    headerPattern = new RegExp(
+      `^(\\w*)(?:\\(([^:]*,)*(${projects.map((project) => escapeRegExp(project)).join('|')}|\\*|deps)(,[^:]*)*\\))?: (.*)$`
+    );
   } else {
-    parserOpts = { headerPattern: new RegExp(`^(\\w*)(?:\\(([^:]*)\\))?: (.*)$`) };
-    releaseRules = baseReleaseRules;
+    headerPattern = new RegExp(`^(\\w*)(?:\\(([^:]*)\\))?: (.*)$`);
   }
 
-  return { releaseRules, parserOpts };
+  return { releaseRules, parserOpts: { headerPattern } };
 }
 
 function escapeRegExp(string: string): string {

--- a/libs/builders/src/semantic-release/lib/get-generate-notes-options.ts
+++ b/libs/builders/src/semantic-release/lib/get-generate-notes-options.ts
@@ -98,7 +98,8 @@ export function getGenerateNotesOptions(projects: string[]): any {
           return commit; // Workspace wide commit, consider it
         }
 
-        if (commit.scope !== '' && !projects.includes(commit.scope)) {
+        const scopes: string[] = commit.scope.split(','); // Support comma separated projects
+        if (commit.scope !== '' && intersect(projects, scopes).length === 0) {
           return; // Omit commit if project is not included in scope
         }
 
@@ -106,4 +107,9 @@ export function getGenerateNotesOptions(projects: string[]): any {
       },
     },
   };
+}
+
+function intersect<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>): ReadonlyArray<T> {
+  const setB = new Set(b);
+  return [...new Set(a)].filter((x) => setB.has(x));
 }

--- a/libs/builders/src/semantic-release/project-builder.ts
+++ b/libs/builders/src/semantic-release/project-builder.ts
@@ -12,6 +12,7 @@ import {
   getProjectDependencies,
   getGithubOptions,
   getBuildTargetOptions,
+  AnalyzeCommitsOptions,
 } from './lib';
 import { InlinePluginSpec, ReleaseOptions, ReleaseProjectOptions } from './models';
 import { inlinePluginBuild } from './plugins/inline-plugin-build';
@@ -59,7 +60,13 @@ async function semanticReleaseProjectBuilder(options: SemanticReleaseProjectSche
     projects: [releaseProjectOptions],
   };
 
-  const commitAnalyzerPlugin: PluginSpec = ['@semantic-release/commit-analyzer', getAnalyzeCommitsOptions([project], options.mode)];
+  const analyzeCommitOptions: AnalyzeCommitsOptions = getAnalyzeCommitsOptions([project], options.mode);
+
+  context.logger.info(`Regex to match commits:`);
+  context.logger.info(analyzeCommitOptions.parserOpts.headerPattern.source);
+  context.logger.info('');
+
+  const commitAnalyzerPlugin: PluginSpec = ['@semantic-release/commit-analyzer', analyzeCommitOptions];
   const releaseNotesPlugin: PluginSpec = ['@semantic-release/release-notes-generator', getGenerateNotesOptions([project])];
   const changelogPlugin: PluginSpec = ['@semantic-release/changelog', { changelogFile: releaseProjectOptions.changelog }];
   const buildPlugin: InlinePluginSpec<ReleaseOptions> = [inlinePluginBuild, releaseOptions];


### PR DESCRIPTION
Closes #377

cc @monitz87