### PR TITLE
feat(builders): :sparkles: validate project names and targets on semrel executors (#525)

### DIFF
--- a/libs/builders/src/semantic-release/plugins/inline-plugin-analyze-commits.spec.ts
+++ b/libs/builders/src/semantic-release/plugins/inline-plugin-analyze-commits.spec.ts
@@ -1,5 +1,6 @@
 import { Commit, Context } from 'semantic-release';
 
+import { getAnalyzeCommitsOptions } from '../lib';
 import { InlinePlugin, ReleaseProjectOptions } from '../models';
 import { inlinePluginAnalyzeCommits } from './inline-plugin-analyze-commits';
 
@@ -124,6 +125,12 @@ describe('@ng-easy/builders:semantic-release', () => {
         const options = getReleaseOptions('project', 'independent');
 
         expect(await analyzeCommits(options, context)).toBe('major');
+      });
+
+      it('should not support invalid project names', () => {
+        expect(() => {
+          getAnalyzeCommitsOptions(['01891$'], 'independent');
+        }).toThrow();
       });
     });
   });

--- a/libs/builders/src/semantic-release/plugins/inline-plugin-analyze-commits.ts
+++ b/libs/builders/src/semantic-release/plugins/inline-plugin-analyze-commits.ts
@@ -7,7 +7,7 @@ import { InlinePlugin, ReleaseProjectOptions } from '../models';
 async function inlineAnalyzeCommits(releaseOptions: ReleaseProjectOptions, context: Context): Promise<string | null> {
   context.logger.log(`Nx Analyze Commits Plugin: VAnalyze Commits`);
 
-  const projects: string[] = [releaseOptions.project, ...releaseOptions.relatedProjects];
+  const projects: string[] = [...new Set([releaseOptions.project, ...releaseOptions.relatedProjects])];
   const analyzeCommitOptions: AnalyzeCommitsOptions = getAnalyzeCommitsOptions(projects, releaseOptions.mode);
 
   context.logger.log(`Regex to match commits: ${analyzeCommitOptions.parserOpts.headerPattern.source}`);

--- a/libs/builders/src/semantic-release/project-builder.ts
+++ b/libs/builders/src/semantic-release/project-builder.ts
@@ -13,6 +13,10 @@ async function semanticReleaseProjectBuilder(options: SemanticReleaseProjectSche
     return failureOutput(context, `Invalid project`);
   }
 
+  if (target !== 'release') {
+    return failureOutput(context, `Builders can only be applied in a target named "release"`);
+  }
+
   context.logger.info(`Configuration for semantic release:`);
   context.logger.info(JSON.stringify(options, null, 2));
 

--- a/libs/builders/src/semantic-release/workspace-builder.ts
+++ b/libs/builders/src/semantic-release/workspace-builder.ts
@@ -14,6 +14,10 @@ async function semanticReleaseWorkspaceBuilder(options: SemanticReleaseWorkspace
     return failureOutput(context, `Invalid project`);
   }
 
+  if (target !== 'release') {
+    return failureOutput(context, `Builders can only be applied in a target named "release"`);
+  }
+
   context.logger.info(`Configuration for semantic release:`);
   context.logger.info(JSON.stringify(options, null, 2));
   context.logger.info('');


### PR DESCRIPTION
Closes #525